### PR TITLE
Adjust to new palette implementation

### DIFF
--- a/src/GGThemr/GGThemr.jl
+++ b/src/GGThemr/GGThemr.jl
@@ -39,8 +39,10 @@ const ggthemr_style = Theme(
 
 function ggthemr(theme::Symbol)
     ct = ColorTheme[theme]
+    palettes = merge(AbstractPlotting.default_palettes, Attributes(color = ct[:swatch][2:end]))
     merge(ggthemr_style, Theme(
-        color = AbstractPlotting.Palette(ct[:swatch][2:end]),
+        palette = palettes,
+        color = ct[:swatch][1],
         backgroundcolor = parse(Color, ct[:background]),
         #colorgradient = parse(Color, ct[:gradient]),
         axis = Theme(

--- a/src/GGThemr/GGThemr.jl
+++ b/src/GGThemr/GGThemr.jl
@@ -18,6 +18,7 @@ ggthemr_colorthemes() = collect(keys(ColorTheme))
 
 const ggthemr_style = Theme(
     linewidth = 2,
+    font = "NotoSans",
     axis = Theme(
         frame = Theme(
             linewidth = 2.5,
@@ -42,7 +43,7 @@ function ggthemr(theme::Symbol)
     palettes = merge(AbstractPlotting.default_palettes, Attributes(color = ct[:swatch][2:end]))
     merge(ggthemr_style, Theme(
         palette = palettes,
-        color = ct[:swatch][1],
+        color = ct[:swatch][2], # maybe it should be ct[:swatch][1], this is the color to use in absence of grouping
         backgroundcolor = parse(Color, ct[:background]),
         #colorgradient = parse(Color, ct[:gradient]),
         axis = Theme(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,16 +19,19 @@ end
 
   AbstractPlotting.set_theme!(ggthemr(:fresh))
 
-  p1 = scatterlines(www, Style(:Minute, :Users),
+  p1 = scatterlines(Data(www), :Minute, :Users,
     Group(color = :Measure, marker = :Measure),
-    markersize = 6, marker = [1,2]);
+    markersize = 6, marker = [:rect, :circle]);
 
-  p2 = plot(StatsMakie.KernelDensity.kde, mtcars,
-    Style(:mpg), Group(color = :cyl));
+  p2 = plot(density, Data(mtcars),
+    :mpg, Group(color = :cyl));
 
-  p4 = boxplot(drivers, Style(:Year, :Deaths));
+  p3 = plot(Position.stack, histogram, Data(diamonds),
+    :price, Group(color = :cut));
 
-  plot(hbox(vbox(p1, p2), vbox(p3, p4))
+  p4 = boxplot(Data(drivers), :Year, :Deaths);
+
+  vbox(hbox(p1, p2), hbox(p3, p4))
 end
 
     driver_x <- scale_x_discrete(breaks = seq(1969, 1984, 3), label = function(x) paste0("'", substr(x, 3, 4)))


### PR DESCRIPTION
This adjusts to the changes in https://github.com/JuliaPlots/AbstractPlotting.jl/pull/54 and in StatsMakie (requires master of both package). With the current code in runtest one gets:

![screenshot from 2018-11-29 13-59-51](https://user-images.githubusercontent.com/6333339/49226955-da44d200-f3df-11e8-925c-a0f3a59cf38e.png)

which looks quite nice. I changed the font to Noto as the default would simply not work on my machine (maybe I can revert that but I kind of like Noto). I am not sure why different plots get different font sizes in the ticks, but this seems like something one should fix in Makie.

I still need to see if it's easy to add the "fill" under the curves in Makie